### PR TITLE
Avoid some crashes in the process scanner thread

### DIFF
--- a/burnt-sushi/src/spotify_process_scanner.rs
+++ b/burnt-sushi/src/spotify_process_scanner.rs
@@ -144,8 +144,12 @@ impl SpotifyProcessScanner {
         while let Some(event) = event_rx.recv().await {
             // scoped to make future Send
             let state = {
-                let window = event.window_handle().unwrap();
-                let process = get_window_process(window)?;
+                let Some(window) = event.window_handle() else {
+                    continue;
+                };
+                let Ok(process) = get_window_process(window) else {
+                    continue;
+                };
                 if !is_spotify_process(process.borrowed()) || !is_main_spotify_window(window) {
                     continue;
                 }


### PR DESCRIPTION
`get_window_process()` can fail for many reasons, one of them being lack of permission to inject into some processes.

Before this change, the process scanner thread could crash by simply launching the Task Manager (`taskmgr.exe`), before we injected into Spotify.

I also added a check for `event.window_handle()`, just to be safe.

Fixes #15